### PR TITLE
Fix a bug preventing `.tsv` file uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.5 (in development)
 * The chat summary feature now supports multiple languages.
 * Fix a bug preventing expired containers from being replaced correctly.
+* [#22](https://github.com/sbslee/streamlit-openai/issues/22): Fix a bug preventing `.tsv` file uploads.
 
 ## 0.1.4 (2025-07-03)
 * Chat history now supports statistically uploaded files.

--- a/streamlit_openai/chat.py
+++ b/streamlit_openai/chat.py
@@ -20,7 +20,7 @@ CHAT_HISTORY_INSTRUCTIONS = """
 CODE_INTERPRETER_EXTENSIONS = [
     ".c", ".cs", ".cpp", ".csv", ".doc", ".docx", ".html", 
     ".java", ".json", ".md", ".pdf", ".php", ".pptx", ".py", 
-    ".rb", ".tex", ".txt", ".css", ".js", ".sh", ".ts", ".csv", 
+    ".rb", ".tex", ".txt", ".css", ".js", ".sh", ".ts", ".tsv", 
     ".jpeg", ".jpg", ".gif", ".pkl", ".png", ".tar", ".xlsx", 
     ".xml", ".zip"
 ]


### PR DESCRIPTION
- Replace the duplicate `.csv` entry in CODE_INTERPRETER_EXTENSIONS with `.tsv`.
- This will fix a bug where uploading a `.tsv` file raises a ValueError because `.tsv` was not included in `CODE_INTERPRETER_EXTENSIONS`.